### PR TITLE
Expose worldstone identificators

### DIFF
--- a/Analyzer.LootGroups.cs
+++ b/Analyzer.LootGroups.cs
@@ -33,12 +33,10 @@ public partial class Analyzer
             // Let's create a special synthetic location for him!
             if (canopyIndex >= 0)
             {
-                zz.Locations.Insert(canopyIndex, new()
-                {
-                    Category = zz.Locations[canopyIndex].Category,
-                    Name = "Ancient Canopy/Luminous Vale",
-                    NameId = "0000_NotApplicable"
-                });
+                zz.Locations.Insert(canopyIndex, new(
+                    name: "Ancient Canopy/Luminous Vale",
+                    category: zz.Locations[canopyIndex].Category
+                ));
             }
 
             int sentinelsKeepIndex = zz.Locations.FindIndex(x => x.Name == "Sentinel's Keep");
@@ -46,11 +44,11 @@ public partial class Analyzer
             // Inject Alepsis-Taura
             if (sentinelsKeepIndex >= 0)
             {
-                zz.Locations.Insert(zz.Locations.Count, new()
+                zz.Locations.Insert(zz.Locations.Count, new(
+                    name: "Alepsis-Taura",
+                    category: zz.Locations[sentinelsKeepIndex].Category
+                    )
                 {
-                    Category = zz.Locations[sentinelsKeepIndex].Category,
-                    Name = "Alepsis-Taura",
-                    NameId = "1159_Zone_Nebula",
                     LootedMarkers = zz.Locations[seekersRestIndex].LootedMarkers
                 });
             }
@@ -240,7 +238,7 @@ public partial class Analyzer
     internal static bool CheckPrerequisites(RolledWorld world, LootItem item, string prerequisite, bool checkHave = true, bool checkCanGet = true)
     {
 
-        if (!checkHave && !checkCanGet) return true; 
+        if (!checkHave && !checkCanGet) return true;
 
         List<string> accountAwards = world.ParentCharacter.ParentDataset.AccountAwards;
         Profile profile = world.ParentCharacter.Profile;

--- a/Analyzer.LootGroups.cs
+++ b/Analyzer.LootGroups.cs
@@ -37,6 +37,7 @@ public partial class Analyzer
                 {
                     Category = zz.Locations[canopyIndex].Category,
                     Name = "Ancient Canopy/Luminous Vale",
+                    NameId = "0000_NotApplicable"
                 });
             }
 
@@ -49,6 +50,7 @@ public partial class Analyzer
                 {
                     Category = zz.Locations[sentinelsKeepIndex].Category,
                     Name = "Alepsis-Taura",
+                    NameId = "1159_Zone_Nebula",
                     LootedMarkers = zz.Locations[seekersRestIndex].LootedMarkers
                 });
             }

--- a/Analyzer.WorldSave.cs
+++ b/Analyzer.WorldSave.cs
@@ -40,11 +40,14 @@ public partial class Analyzer
 
         int difficulty = navigator.GetProperty("Difficulty", campaignMeta)?.Get<int>() ?? 1;
         TimeSpan? tp = navigator.GetProperty("PlayTime", campaignMeta)?.Get<TimeSpan>();
+        string? respawnLinkNameId = navigator.GetProperty("RespawnLinkNameID", campaignMeta)?.Get<FName>().Name;
+
         RolledWorld rolledWorld = new()
         {
             QuestInventory = questInventory,
             Difficulty = Difficulties[difficulty],
             Playtime = tp,
+            RespawnLinkNameId = respawnLinkNameId,
         };
         rolledWorld.Zones =
         [

--- a/Analyzer.WorldSave.cs
+++ b/Analyzer.WorldSave.cs
@@ -57,17 +57,9 @@ public partial class Analyzer
         ];
 
         string? respawnLinkNameId = navigator.GetProperty("RespawnLinkNameID", campaignMeta)?.Get<FName>().Name;
-        if (string.IsNullOrEmpty(respawnLinkNameId))
-        {
-            rolledWorld.RespawnPoint = null;
-        }
-        else
-        {
-            string? respawnPoint = rolledWorld.AllZones.SelectMany(x => x.Locations)
-                .Select(x => x.GetWorldStoneById(respawnLinkNameId))
-                .SingleOrDefault(x => x != null);
-            rolledWorld.RespawnPoint = respawnPoint;
-        }
+        rolledWorld.RespawnPoint = rolledWorld.AllZones.SelectMany(x => x.Locations)
+            .Select(x => x.GetWorldStoneById(respawnLinkNameId))
+            .SingleOrDefault(x => x != null);
 
         return rolledWorld;
     }
@@ -101,17 +93,9 @@ public partial class Analyzer
         ];
 
         string? respawnLinkNameId = navigator.GetProperty("RespawnLinkNameID", adventureMeta)?.Get<FName>().Name;
-        if (string.IsNullOrEmpty(respawnLinkNameId))
-        {
-            rolledWorld.RespawnPoint = null;
-        }
-        else
-        {
-            string? respawnPoint = rolledWorld.AllZones.SelectMany(x => x.Locations)
-                .Select(x => x.GetWorldStoneById(respawnLinkNameId))
-                .SingleOrDefault(x => x != null);
-            rolledWorld.RespawnPoint = respawnPoint;
-        }
+        rolledWorld.RespawnPoint = rolledWorld.AllZones.SelectMany(x => x.Locations)
+            .Select(x => x.GetWorldStoneById(respawnLinkNameId))
+            .SingleOrDefault(x => x != null);
 
         return rolledWorld;
     }
@@ -214,7 +198,7 @@ public partial class Analyzer
                 {
                     case "EZoneLinkType::Waypoint":
                         waypoints.Add(linkLabel);
-                        waypointIdMap[linkLabel] = name;
+                        waypointIdMap[name] = linkLabel;
                         break;
                     case "EZoneLinkType::Checkpoint":
                         break;

--- a/Analyzer.WorldSave.cs
+++ b/Analyzer.WorldSave.cs
@@ -340,8 +340,8 @@ public partial class Analyzer
         }
 
         Zone zone = new(zoneParent) { Locations = result };
-        if (finished.HasValue) zone.SetFinished(finished.Value);
-        if (story != null) zone.SetStoryId(story);
+        if (finished.HasValue) zone.Finished = finished.Value;
+        if (story != null) zone.StoryId = story;
         return zone;
 
     }

--- a/Analyzer.WorldSave.cs
+++ b/Analyzer.WorldSave.cs
@@ -73,12 +73,14 @@ public partial class Analyzer
 
         var difficulty = navigator.GetProperty("Difficulty", adventureMeta)?.Get<int>() ?? 1;
         TimeSpan? tp = navigator.GetProperty("PlayTime", adventureMeta)?.Get<TimeSpan>();
+        string? respawnLinkNameId = navigator.GetProperty("RespawnLinkNameID", adventureMeta)?.Get<FName>().Name;
 
         RolledWorld rolledWorld = new()
         {
             QuestInventory = questInventory,
             Difficulty = Difficulties[difficulty],
             Playtime = tp,
+            RespawnLinkNameId = respawnLinkNameId,
         };
         rolledWorld.Zones =
         [
@@ -151,6 +153,7 @@ public partial class Analyzer
             Actor current = queue.Dequeue();
             PropertyBag pb = current.GetZoneActorProperties()!;
             string label = pb["Label"].ToStringValue()!;
+            string labelId = pb["NameID"].ToStringValue()!;
             int zoneId = pb["ID"].Get<int>();
             int questId = pb["QuestID"].Get<int>();
 
@@ -159,7 +162,7 @@ public partial class Analyzer
 
             ArrayStructProperty links = pb["ZoneLinks"].Get<ArrayStructProperty>();
 
-            List<string> waypoints = [];
+            List<WorldStone> waypoints = [];
             List<string> connectsTo = [];
 
             foreach (object? o in links.Items)
@@ -183,7 +186,7 @@ public partial class Analyzer
                 switch (type)
                 {
                     case "EZoneLinkType::Waypoint":
-                        waypoints.Add(linkLabel);
+                        waypoints.Add(new WorldStone { Name = linkLabel, NameId = name });
                         break;
                     case "EZoneLinkType::Checkpoint":
                         break;
@@ -238,6 +241,7 @@ public partial class Analyzer
             Location l = new()
             {
                 Name = label,
+                NameId = labelId,
                 DropReferences = [],
                 WorldDrops = [],
                 WorldStones = waypoints,

--- a/Model/Location.cs
+++ b/Model/Location.cs
@@ -23,11 +23,11 @@ public class Location
         Name = name;
         Category = category;
         WorldStones = worldStones;
-        WorldStoneIdMap = worldStoneIdMap;
         Connections = connections;
+        _worldStoneIdMap = worldStoneIdMap;
     }
 
-    private readonly Dictionary<string, string> WorldStoneIdMap = [];
+    private readonly Dictionary<string, string> _worldStoneIdMap = [];
 
     public string Name;
     public string Category;
@@ -132,8 +132,10 @@ public class Location
         };
     }
 
-    public string? GetWorldStoneById(string worldStoneId)
+    public string? GetWorldStoneById(string? worldStoneId)
     {
-        return WorldStoneIdMap.FirstOrDefault(x => x.Value.Equals(worldStoneId)).Key;
+        if (worldStoneId == null) return null;
+        _worldStoneIdMap.TryGetValue(worldStoneId, out string? value);
+        return value;
     }
 }

--- a/Model/Location.cs
+++ b/Model/Location.cs
@@ -6,7 +6,8 @@ namespace lib.remnant2.analyzer.Model;
 public class Location
 {
     public required string Name;
-    public List<string> WorldStones = [];
+    public required string NameId;
+    public List<WorldStone> WorldStones = [];
     public List<string> Connections = [];
     public bool TraitBook;
     public bool TraitBookLooted;
@@ -95,7 +96,8 @@ public class Location
     public static Location Ward13 => new()
     {
         Name = "Ward 13",
-        WorldStones = [ "Ward 13" ],
+        NameId = "2_Zone",
+        WorldStones = [ new() { Name = "Ward 13", NameId = "2_Waypoint_Town" } ],
         Connections = [],
         WorldDrops = [],
         DropReferences = [],

--- a/Model/Location.cs
+++ b/Model/Location.cs
@@ -5,20 +5,43 @@ namespace lib.remnant2.analyzer.Model;
 [DebuggerDisplay("{Name}")]
 public class Location
 {
-    public required string Name;
-    public required string NameId;
-    public List<WorldStone> WorldStones = [];
+    // Simplified init
+    public Location(string name, string category)
+    {
+        Name = name;
+        Category = category;
+    }
+
+    // Full init including world stones
+    public Location(
+        string name,
+        string category,
+        List<string> worldStones,
+        Dictionary<string, string> worldStoneIdMap,
+        List<string> connections)
+    {
+        Name = name;
+        Category = category;
+        WorldStones = worldStones;
+        WorldStoneIdMap = worldStoneIdMap;
+        Connections = connections;
+    }
+
+    private readonly Dictionary<string, string> WorldStoneIdMap = [];
+
+    public string Name;
+    public string Category;
+    public List<string> WorldStones = [];
     public List<string> Connections = [];
+
     public bool TraitBook;
     public bool TraitBookLooted;
     public bool Simulacrum;
     public bool SimulacrumLooted;
     public List<DropReference> WorldDrops = [];
-    public List<DropReference> DropReferences =[];
-    public required string Category;
-    public List<LootGroup> LootGroups=[];
+    public List<DropReference> DropReferences = [];
+    public List<LootGroup> LootGroups = [];
     public List<LootedMarker> LootedMarkers = [];
-
 
     public bool Bloodmoon
     {
@@ -93,16 +116,24 @@ public class Location
         }
     }
 
-    public static Location Ward13 => new()
+    public static Location GetWard13()
     {
-        Name = "Ward 13",
-        NameId = "2_Zone",
-        WorldStones = [ new() { Name = "Ward 13", NameId = "2_Waypoint_Town" } ],
-        Connections = [],
-        WorldDrops = [],
-        DropReferences = [],
-        Category = "Ward 13",
-        LootGroups = [],
-        LootedMarkers = []
-    };
+        return new Location(
+            name: "Ward 13",
+            category: "Ward 13",
+            worldStones: ["Ward 13"],
+            worldStoneIdMap: new() { { "Ward 13", "2_Waypoint_Town" } },
+            connections: [])
+        {
+            WorldDrops = [],
+            DropReferences = [],
+            LootGroups = [],
+            LootedMarkers = []
+        };
+    }
+
+    public string? GetWorldStoneById(string worldStoneId)
+    {
+        return WorldStoneIdMap.FirstOrDefault(x => x.Value.Equals(worldStoneId)).Key;
+    }
 }

--- a/Model/RolledWorld.cs
+++ b/Model/RolledWorld.cs
@@ -5,7 +5,7 @@ public class RolledWorld
 {
     public RolledWorld()
     {
-        Ward13 = new(this) { Locations = [ Location.Ward13 ] };
+        Ward13 = new(this) { Locations = [ Location.GetWard13() ] };
     }
     public List<Zone> Zones = [];
     public required List<string> QuestInventory;
@@ -21,7 +21,7 @@ public class RolledWorld
 
     public required string Difficulty;
     public TimeSpan? Playtime;
-    public string? RespawnLinkNameId;
+    public string? RespawnPoint;
 
     public bool CanGetItem(string item)
     {

--- a/Model/RolledWorld.cs
+++ b/Model/RolledWorld.cs
@@ -21,6 +21,7 @@ public class RolledWorld
 
     public required string Difficulty;
     public TimeSpan? Playtime;
+    public string? RespawnLinkNameId;
 
     public bool CanGetItem(string item)
     {

--- a/Model/WorldStone.cs
+++ b/Model/WorldStone.cs
@@ -1,0 +1,10 @@
+﻿using System.Diagnostics;
+
+namespace lib.remnant2.analyzer.Model;
+
+[DebuggerDisplay("{Name}")]
+public class WorldStone
+{
+    public required string Name { get; set; }
+    public required string NameId { get; set; }
+}

--- a/Model/Zone.cs
+++ b/Model/Zone.cs
@@ -7,7 +7,6 @@ public class Zone(RolledWorld parent)
 {
     public required List<Location> Locations;
     public RolledWorld Parent { get; } = parent;
-    private string? _story;
     private bool? _finished;
 
     public string Name
@@ -22,15 +21,7 @@ public class Zone(RolledWorld parent)
                                                || Parent.CanGetItem(x.Properties["Prerequisite"])));
     }
 
-    public void SetStoryId(string story)
-    {
-        _story = story;
-    }
-
-    public void SetFinished(bool finished)
-    {
-        _finished = finished;
-    }
+    public string? StoryId { get; set; }
 
     public string Story
     {
@@ -40,7 +31,7 @@ public class Zone(RolledWorld parent)
             if (Name == "Labyrinth") return "The Labyrinth";
             if (Name == "Root Earth") return "Root Earth";
 
-            return ItemDb.GetItemById($"Quest_{_story}").Name;
+            return ItemDb.GetItemById($"Quest_{StoryId}").Name;
         }
     }
 
@@ -55,6 +46,7 @@ public class Zone(RolledWorld parent)
 
             return _finished!.Value;
         }
+        set { _finished = value; }
     }
 
     public bool CompletesBiome


### PR DESCRIPTION
Save Worldstone identificators and `RespawnLinkNameID`. This will allow for displaying the last known character location. We can also add a `RespawnZoneID` that is right there next to it, but I can't think of a use for it yet.

Save NameId for locations. I think exposing this is pertinent. Getting this information later on is almost impossible. I could not come up with a fitting id for the Walt workaround ("Ancient Canopy/Luminous Vale"), so I put "0000_NotApplicable" there for now.

Small refactor for properties in Zone.cs, with a side effect of also exposing StoryId for those who might want it. It's possible to do a reverse lookup against db file to get it, but I see no reason not to provide it.