### PR TITLE
Add respawn point detection for checkpoints and zone connections

### DIFF
--- a/Analyzer.WorldSave.cs
+++ b/Analyzer.WorldSave.cs
@@ -171,8 +171,8 @@ public partial class Analyzer
 
             ArrayStructProperty links = pb["ZoneLinks"].Get<ArrayStructProperty>();
             List<string> checkpoints = [];
-            Dictionary<string, string> waypointIdMap = [];
-            Dictionary<string, string> connectionsIdMap = [];
+            List<(string, string)> waypointIdMap = [];
+            List<(string, string)> connectionsIdMap = [];
 
             foreach (object? o in links.Items)
             {
@@ -194,7 +194,7 @@ public partial class Analyzer
                 switch (type)
                 {
                     case "EZoneLinkType::Waypoint":
-                        waypointIdMap[linkName] = linkLabel;
+                        waypointIdMap.Add((linkName, linkLabel));
                         break;
                     case "EZoneLinkType::Checkpoint":
                         checkpoints.Add(linkName);
@@ -219,7 +219,7 @@ public partial class Analyzer
                                 world == labyrinth;
                             if (!isLabyrinth)
                             {
-                                connectionsIdMap[linkName] = destinationZoneLabel;
+                                connectionsIdMap.Add((linkName, destinationZoneLabel));
                                 if (!seen.Contains(destinationZoneLabel))
                                 {
                                     queue.Enqueue(destinationZone);

--- a/Analyzer.WorldSave.cs
+++ b/Analyzer.WorldSave.cs
@@ -74,8 +74,7 @@ public partial class Analyzer
         if (respawnLinkNameId != null)
         {
             var respawnPoint = FindRespawnPoint(respawnLinkNameId, rolledWorld.AllZones);
-            rolledWorld.RespawnPoint = respawnPoint.Name;
-            rolledWorld.RespawnPointType = respawnPoint.Type;
+            rolledWorld.RespawnPoint = respawnPoint;
         }
 
         return rolledWorld;

--- a/Analyzer.WorldSave.cs
+++ b/Analyzer.WorldSave.cs
@@ -210,7 +210,6 @@ public partial class Analyzer
                             Actor destinationZone = zoneActors.Single(x =>
                                 x.GetZoneActorProperties()!["NameID"].ToStringValue() == destinationZoneName);
                             string destinationZoneLabel = destinationZone.GetZoneActorProperties()!["Label"].ToStringValue()!;
-                            string destinationZoneId = destinationZone.GetZoneActorProperties()!["NameID"].ToStringValue()!;
 
                             if (linkLabel == "Malefic Palace" && destinationZoneLabel == "Beatific Palace"
                                 || destinationZoneLabel == "Malefic Palace" && linkLabel == "Beatific Palace") continue;

--- a/Analyzer.WorldSave.cs
+++ b/Analyzer.WorldSave.cs
@@ -73,15 +73,15 @@ public partial class Analyzer
         string? respawnLinkNameId = navigator.GetProperty("RespawnLinkNameID", meta)?.Get<FName>().Name;
         if (respawnLinkNameId != null)
         {
-            var respawnPoint = FindRespawnPoint(respawnLinkNameId, rolledWorld.AllZones);
-            rolledWorld.RespawnPoint = respawnPoint.name;
-            rolledWorld.RespawnPointType = respawnPoint.type;
+            var (name, type) = FindRespawnPoint(respawnLinkNameId, rolledWorld.AllZones);
+            rolledWorld.RespawnPoint = name;
+            rolledWorld.RespawnPointType = type;
         }
 
         return rolledWorld;
     }
 
-    private static (string name, RespawnPointType type) FindRespawnPoint(string respawnLinkNameId, List<Zone> zones)
+    private static (string? name, RespawnPointType type) FindRespawnPoint(string respawnLinkNameId, List<Zone> zones)
     {
         var worldStoneName = zones.SelectMany(x => x.Locations)
                 .Select(x => x.GetWorldStoneById(respawnLinkNameId))
@@ -97,7 +97,7 @@ public partial class Analyzer
         if (targetLocation is not null) return ($"{targetLocation.Name} <-> {targetLocation.GetLinkDestinationById(respawnLinkNameId)}", RespawnPointType.ZoneTransition);
 
         // Nothing is found
-        return (string.Empty, RespawnPointType.None);
+        return (null, RespawnPointType.None);
     }
 
     private static List<string> GetQuestInventory(PropertyBag inventoryBag)

--- a/Analyzer.WorldSave.cs
+++ b/Analyzer.WorldSave.cs
@@ -73,31 +73,31 @@ public partial class Analyzer
         string? respawnLinkNameId = navigator.GetProperty("RespawnLinkNameID", meta)?.Get<FName>().Name;
         if (respawnLinkNameId != null)
         {
-            var (name, type) = FindRespawnPoint(respawnLinkNameId, rolledWorld.AllZones);
-            rolledWorld.RespawnPoint = name;
-            rolledWorld.RespawnPointType = type;
+            var respawnPoint = FindRespawnPoint(respawnLinkNameId, rolledWorld.AllZones);
+            rolledWorld.RespawnPoint = respawnPoint.Name;
+            rolledWorld.RespawnPointType = respawnPoint.Type;
         }
 
         return rolledWorld;
     }
 
-    private static (string? name, RespawnPointType type) FindRespawnPoint(string respawnLinkNameId, List<Zone> zones)
+    private static RespawnPoint FindRespawnPoint(string respawnLinkNameId, List<Zone> zones)
     {
         var worldStoneName = zones.SelectMany(x => x.Locations)
                 .Select(x => x.GetWorldStoneById(respawnLinkNameId))
                 .SingleOrDefault(x => x != null);
-        if (worldStoneName is not null) return (worldStoneName, RespawnPointType.Waypoint);
+        if (worldStoneName is not null) return new RespawnPoint(worldStoneName, RespawnPointType.Waypoint);
 
         var checkpointName = zones.SelectMany(x => x.Locations)
                 .FirstOrDefault(x => x.ContainsCheckpointId(respawnLinkNameId))?.Name;
-        if (checkpointName is not null) return (checkpointName, RespawnPointType.Checkpoint);
+        if (checkpointName is not null) return new RespawnPoint(checkpointName, RespawnPointType.Checkpoint);
         
         var targetLocation = zones.SelectMany(x => x.Locations)
                 .FirstOrDefault(x => x.GetLinkDestinationById(respawnLinkNameId) != null);
-        if (targetLocation is not null) return ($"{targetLocation.Name} <-> {targetLocation.GetLinkDestinationById(respawnLinkNameId)}", RespawnPointType.ZoneTransition);
+        if (targetLocation is not null) return new RespawnPoint($"{targetLocation.Name}/{targetLocation.GetLinkDestinationById(respawnLinkNameId)}", RespawnPointType.ZoneTransition);
 
         // Nothing is found
-        return (null, RespawnPointType.None);
+        return new RespawnPoint(null, RespawnPointType.None);
     }
 
     private static List<string> GetQuestInventory(PropertyBag inventoryBag)

--- a/Analyzer.WorldSave.cs
+++ b/Analyzer.WorldSave.cs
@@ -205,8 +205,6 @@ public partial class Analyzer
                         if (destinationZoneName != "None" && !linkName.Contains("CardDoor") &&
                             destinationZoneName != "2_Zone")
                         {
-                            // TODO: Test whether you can respawn at card door. If so, will need to add it as a connection to find respawn point later
-
                             Actor destinationZone = zoneActors.Single(x =>
                                 x.GetZoneActorProperties()!["NameID"].ToStringValue() == destinationZoneName);
                             string destinationZoneLabel = destinationZone.GetZoneActorProperties()!["Label"].ToStringValue()!;

--- a/Analyzer.WorldSave.cs
+++ b/Analyzer.WorldSave.cs
@@ -3,7 +3,6 @@ using lib.remnant2.saves.Model.Parts;
 using lib.remnant2.saves.Model.Properties;
 using lib.remnant2.saves.Model;
 using lib.remnant2.saves.Navigation;
-using lib.remnant2.analyzer.Enums;
 
 namespace lib.remnant2.analyzer;
 
@@ -80,23 +79,23 @@ public partial class Analyzer
         return rolledWorld;
     }
 
-    private static RespawnPoint FindRespawnPoint(string respawnLinkNameId, List<Zone> zones)
+    private static RespawnPoint? FindRespawnPoint(string respawnLinkNameId, List<Zone> zones)
     {
         var worldStoneName = zones.SelectMany(x => x.Locations)
                 .Select(x => x.GetWorldStoneById(respawnLinkNameId))
                 .SingleOrDefault(x => x != null);
-        if (worldStoneName is not null) return new RespawnPoint(worldStoneName, RespawnPointType.Waypoint);
+        if (worldStoneName is not null) return new RespawnPoint(worldStoneName, RespawnPoint.RespawnPointType.Waypoint);
 
         var checkpointName = zones.SelectMany(x => x.Locations)
                 .FirstOrDefault(x => x.ContainsCheckpointId(respawnLinkNameId))?.Name;
-        if (checkpointName is not null) return new RespawnPoint(checkpointName, RespawnPointType.Checkpoint);
+        if (checkpointName is not null) return new RespawnPoint(checkpointName, RespawnPoint.RespawnPointType.Checkpoint);
         
         var targetLocation = zones.SelectMany(x => x.Locations)
                 .FirstOrDefault(x => x.GetLinkDestinationById(respawnLinkNameId) != null);
-        if (targetLocation is not null) return new RespawnPoint($"{targetLocation.Name}/{targetLocation.GetLinkDestinationById(respawnLinkNameId)}", RespawnPointType.ZoneTransition);
+        if (targetLocation is not null) return new RespawnPoint($"{targetLocation.Name}/{targetLocation.GetLinkDestinationById(respawnLinkNameId)}", RespawnPoint.RespawnPointType.ZoneTransition);
 
         // Nothing is found
-        return new RespawnPoint(null, RespawnPointType.None);
+        return null;
     }
 
     private static List<string> GetQuestInventory(PropertyBag inventoryBag)

--- a/Enums/RespawnPointType.cs
+++ b/Enums/RespawnPointType.cs
@@ -1,0 +1,8 @@
+﻿namespace lib.remnant2.analyzer.Enums;
+public enum RespawnPointType
+{
+    None,
+    Waypoint,
+    Checkpoint,
+    ZoneTransition
+}

--- a/Enums/RespawnPointType.cs
+++ b/Enums/RespawnPointType.cs
@@ -1,8 +1,0 @@
-﻿namespace lib.remnant2.analyzer.Enums;
-public enum RespawnPointType
-{
-    None,
-    Waypoint,
-    Checkpoint,
-    ZoneTransition
-}

--- a/Model/Location.cs
+++ b/Model/Location.cs
@@ -16,23 +16,25 @@ public class Location
     public Location(
         string name,
         string category,
-        List<string> worldStones,
         Dictionary<string, string> worldStoneIdMap,
-        List<string> connections)
+        Dictionary<string, string> connectionsIdMap,
+        List<string> checkpoints)
     {
         Name = name;
         Category = category;
-        WorldStones = worldStones;
-        Connections = connections;
         _worldStoneIdMap = worldStoneIdMap;
+        _connectionsIdMap = connectionsIdMap;
+        _checkpoints = checkpoints;
     }
 
-    private readonly Dictionary<string, string> _worldStoneIdMap = [];
+    private readonly Dictionary<string, string> _worldStoneIdMap = []; // <waypointId, waypointName>
+    private readonly Dictionary<string, string> _connectionsIdMap = []; // <LinkId, DestinationName>
+    private readonly List<string> _checkpoints = [];
 
     public string Name;
     public string Category;
-    public List<string> WorldStones = [];
-    public List<string> Connections = [];
+    public List<string> WorldStones => _worldStoneIdMap.Values.ToList();
+    public List<string> Connections => _connectionsIdMap.Values.Distinct().ToList();
 
     public bool TraitBook;
     public bool TraitBookLooted;
@@ -121,9 +123,9 @@ public class Location
         return new Location(
             name: "Ward 13",
             category: "Ward 13",
-            worldStones: ["Ward 13"],
-            worldStoneIdMap: new() { { "Ward 13", "2_Waypoint_Town" } },
-            connections: [])
+            worldStoneIdMap: new() { { "2_Waypoint_Town", "Ward 13" } },
+            connectionsIdMap: [],
+            checkpoints: [])
         {
             WorldDrops = [],
             DropReferences = [],
@@ -137,5 +139,18 @@ public class Location
         if (worldStoneId == null) return null;
         _worldStoneIdMap.TryGetValue(worldStoneId, out string? value);
         return value;
+    }
+
+    public string? GetLinkDestinationById(string? zoneLinkId)
+    {
+        if (zoneLinkId == null) return null;
+        _connectionsIdMap.TryGetValue(zoneLinkId, out string? value);
+        return value;
+    }
+
+    public bool ContainsCheckpointId(string checkpointId)
+    {
+        if (_checkpoints.Contains(checkpointId)) return true;
+        return false;
     }
 }

--- a/Model/Location.cs
+++ b/Model/Location.cs
@@ -1,4 +1,6 @@
 ﻿using System.Diagnostics;
+using Waypoint = (string waypointId, string waypointName);
+using Connection = (string linkId, string destinationName);
 
 namespace lib.remnant2.analyzer.Model;
 
@@ -16,8 +18,8 @@ public class Location
     public Location(
         string name,
         string category,
-        List<(string, string)> worldStoneIdMap,
-        List<(string, string)> connectionsIdMap,
+        List<Waypoint> worldStoneIdMap,
+        List<Connection> connectionsIdMap,
         List<string> checkpoints)
     {
         Name = name;
@@ -27,8 +29,8 @@ public class Location
         _checkpoints = checkpoints;
     }
 
-    private readonly List<(string waypointId, string waypointName)> _worldStoneIdMap = [];
-    private readonly List<(string linkId, string destinationName)> _connectionsIdMap = [];
+    private readonly List<Waypoint> _worldStoneIdMap = [];
+    private readonly List<Connection> _connectionsIdMap = [];
     private readonly List<string> _checkpoints = [];
 
     public string Name;
@@ -149,7 +151,6 @@ public class Location
 
     public bool ContainsCheckpointId(string checkpointId)
     {
-        if (_checkpoints.Contains(checkpointId)) return true;
-        return false;
+        return _checkpoints.Contains(checkpointId);
     }
 }

--- a/Model/Location.cs
+++ b/Model/Location.cs
@@ -16,8 +16,8 @@ public class Location
     public Location(
         string name,
         string category,
-        Dictionary<string, string> worldStoneIdMap,
-        Dictionary<string, string> connectionsIdMap,
+        List<(string, string)> worldStoneIdMap,
+        List<(string, string)> connectionsIdMap,
         List<string> checkpoints)
     {
         Name = name;
@@ -27,14 +27,14 @@ public class Location
         _checkpoints = checkpoints;
     }
 
-    private readonly Dictionary<string, string> _worldStoneIdMap = []; // <waypointId, waypointName>
-    private readonly Dictionary<string, string> _connectionsIdMap = []; // <LinkId, DestinationName>
+    private readonly List<(string waypointId, string waypointName)> _worldStoneIdMap = []; // <waypointId, waypointName>
+    private readonly List<(string linkId, string destinationName)> _connectionsIdMap = []; // <LinkId, DestinationName>
     private readonly List<string> _checkpoints = [];
 
     public string Name;
     public string Category;
-    public List<string> WorldStones => _worldStoneIdMap.Values.ToList();
-    public List<string> Connections => _connectionsIdMap.Values.Distinct().ToList();
+    public List<string> WorldStones => _worldStoneIdMap.Select(x => x.waypointName).ToList();
+    public List<string> Connections => _connectionsIdMap.Select(x => x.destinationName).Distinct().ToList();
 
     public bool TraitBook;
     public bool TraitBookLooted;
@@ -123,7 +123,7 @@ public class Location
         return new Location(
             name: "Ward 13",
             category: "Ward 13",
-            worldStoneIdMap: new() { { "2_Waypoint_Town", "Ward 13" } },
+            worldStoneIdMap: [( "2_Waypoint_Town", "Ward 13" )],
             connectionsIdMap: [],
             checkpoints: [])
         {
@@ -137,15 +137,13 @@ public class Location
     public string? GetWorldStoneById(string? worldStoneId)
     {
         if (worldStoneId == null) return null;
-        _worldStoneIdMap.TryGetValue(worldStoneId, out string? value);
-        return value;
+        return _worldStoneIdMap.FirstOrDefault(x => x.waypointId.Equals(worldStoneId)).waypointName;
     }
 
     public string? GetLinkDestinationById(string? zoneLinkId)
     {
         if (zoneLinkId == null) return null;
-        _connectionsIdMap.TryGetValue(zoneLinkId, out string? value);
-        return value;
+        return _connectionsIdMap.FirstOrDefault(x => x.linkId.Equals(zoneLinkId)).destinationName;
     }
 
     public bool ContainsCheckpointId(string checkpointId)

--- a/Model/Location.cs
+++ b/Model/Location.cs
@@ -27,14 +27,15 @@ public class Location
         _checkpoints = checkpoints;
     }
 
-    private readonly List<(string waypointId, string waypointName)> _worldStoneIdMap = []; // <waypointId, waypointName>
-    private readonly List<(string linkId, string destinationName)> _connectionsIdMap = []; // <LinkId, DestinationName>
+    private readonly List<(string waypointId, string waypointName)> _worldStoneIdMap = [];
+    private readonly List<(string linkId, string destinationName)> _connectionsIdMap = [];
     private readonly List<string> _checkpoints = [];
 
     public string Name;
     public string Category;
     public List<string> WorldStones => _worldStoneIdMap.Select(x => x.waypointName).ToList();
-    public List<string> Connections => _connectionsIdMap.Select(x => x.destinationName).Distinct().ToList();
+    public List<string> Connections => _connectionsIdMap.GroupBy(x => x.destinationName)
+        .Select(g => g.Count() > 1 ? $"{g.Key} x{g.Count()}" : g.Key).ToList();
 
     public bool TraitBook;
     public bool TraitBookLooted;

--- a/Model/RespawnPoint.cs
+++ b/Model/RespawnPoint.cs
@@ -1,0 +1,14 @@
+﻿using lib.remnant2.analyzer.Enums;
+
+namespace lib.remnant2.analyzer.Model;
+public class RespawnPoint
+{
+    public RespawnPoint(string? name, RespawnPointType type)
+    {
+        Name = name;
+        Type = type;
+    }
+
+    public string? Name { get; set; }
+    public RespawnPointType Type { get; set; }
+}

--- a/Model/RespawnPoint.cs
+++ b/Model/RespawnPoint.cs
@@ -1,14 +1,20 @@
-﻿using lib.remnant2.analyzer.Enums;
+﻿namespace lib.remnant2.analyzer.Model;
 
-namespace lib.remnant2.analyzer.Model;
-public class RespawnPoint
+public class RespawnPoint(string name, RespawnPoint.RespawnPointType type)
 {
-    public RespawnPoint(string? name, RespawnPointType type)
+    public enum RespawnPointType
     {
-        Name = name;
-        Type = type;
+        None,
+        Waypoint,
+        Checkpoint,
+        ZoneTransition
     }
 
-    public string? Name { get; set; }
-    public RespawnPointType Type { get; set; }
+    public string Name { get; set; } = name;
+    public RespawnPointType Type { get; set; } = type;
+
+    public override string ToString()
+    {
+        return $"{Name} ({Type})";
+    }
 }

--- a/Model/RolledWorld.cs
+++ b/Model/RolledWorld.cs
@@ -23,8 +23,7 @@ public class RolledWorld
 
     public required string Difficulty;
     public TimeSpan? Playtime;
-    public string? RespawnPoint;
-    public RespawnPointType RespawnPointType;
+    public RespawnPoint RespawnPoint = new(null, RespawnPointType.None);
 
     public List <LootGroup> AdditionalItems =[];
 

--- a/Model/RolledWorld.cs
+++ b/Model/RolledWorld.cs
@@ -1,4 +1,6 @@
-﻿namespace lib.remnant2.analyzer.Model;
+﻿using lib.remnant2.analyzer.Enums;
+
+namespace lib.remnant2.analyzer.Model;
 
 // Represents part of the data from a single save_N.sav: either adventure data or campaign data
 public class RolledWorld

--- a/Model/RolledWorld.cs
+++ b/Model/RolledWorld.cs
@@ -22,6 +22,7 @@ public class RolledWorld
     public required string Difficulty;
     public TimeSpan? Playtime;
     public string? RespawnPoint;
+    public RespawnPointType RespawnPointType;
 
     public List <LootGroup> AdditionalItems =[];
 

--- a/Model/RolledWorld.cs
+++ b/Model/RolledWorld.cs
@@ -1,6 +1,4 @@
-﻿using lib.remnant2.analyzer.Enums;
-
-namespace lib.remnant2.analyzer.Model;
+﻿namespace lib.remnant2.analyzer.Model;
 
 // Represents part of the data from a single save_N.sav: either adventure data or campaign data
 public class RolledWorld
@@ -23,7 +21,7 @@ public class RolledWorld
 
     public required string Difficulty;
     public TimeSpan? Playtime;
-    public RespawnPoint RespawnPoint = new(null, RespawnPointType.None);
+    public RespawnPoint? RespawnPoint;
 
     public List <LootGroup> AdditionalItems =[];
 


### PR DESCRIPTION
Now checkpoint and zone transitions are also considered when trying to find the respawn point.

Notes:
- Checkpoints are a simple list due to a fact that the all share a name (the name of the zone they are in). There is no way to tell them apart other than by IDs. We will only be able to tell that the respawn point is at the checkpoint, but not which one. Granted, the game behaves the same way.
- I simplified `WorldStones` and `Connections` properties in `Location`. We already have duplicate data in maps, there is no need to assign them manually.
- With regards to "TODO" comment: I am not 100% sure why checks in `case "EZoneLinkType::Link":` are what they are, so I decided to not change anything there for now, but if respawning behind the card door is possible, it would make sense to add this "location" to the list, i.e. exclude it from the condition.
- In case of zone transition, the format of the string is `$"{currentZone} <-> {destinationZone}`. I decided to save it like this as opposed to "Transition from X to Y" in case the consumer (me) wants to present it differently. Parsing this is as simple as .split("<->"), as opposed to pulling out strings from a "pretty-fied" result. Maybe even a '/' would be enough?