### PR TITLE
Change .Single to .Last to work around stale adventure blocks

### DIFF
--- a/Analyzer.WorldSave.cs
+++ b/Analyzer.WorldSave.cs
@@ -29,7 +29,7 @@ public partial class Analyzer
         
         UObject main = navigator.GetObjects("pc:/Game/Maps/Main.Main:PersistentLevel").Single();
 
-        UObject meta = main.Properties!["Blob"].Get<PersistenceContainer>().Actors.Select(x => x.Value).Single(x => x.ToString()!.StartsWith(data.Selector)).Archive.Objects[0];
+        UObject meta = main.Properties!["Blob"].Get<PersistenceContainer>().Actors.Select(x => x.Value).Last(x => x.ToString()!.StartsWith(data.Selector)).Archive.Objects[0];
 
         int rollId = meta.Properties!["ID"].Get<int>();
         UObject rollObject = navigator.GetObjects($"pc:/Game/Quest_{rollId}_Container.Quest_Container:PersistentLevel").Single();

--- a/Model/LootItemContext.cs
+++ b/Model/LootItemContext.cs
@@ -17,7 +17,7 @@ internal class LootItemContext
         Navigator navigator = World.ParentCharacter.WorldNavigator!;
         UObject main = navigator.GetObjects("pc:/Game/Maps/Main.Main:PersistentLevel").Single();
         string selector = World.IsCampaign ? "Quest_Campaign" : "Quest_AdventureMode";
-        return main.Properties!["Blob"].Get<PersistenceContainer>().Actors.Select(x => x.Value).Single(x => x.ToString()!.StartsWith(selector)).Archive.Objects[0];
+        return main.Properties!["Blob"].Get<PersistenceContainer>().Actors.Select(x => x.Value).Last(x => x.ToString()!.StartsWith(selector)).Archive.Objects[0];
     }
 
     public UObject? GetRollObject()


### PR DESCRIPTION
Sometimes save files have stale adventure blocks, which break the parser. I suggest always taking the latest (last) adventure object.

Issue in question:
<img width="689" height="229" alt="image" src="https://github.com/user-attachments/assets/b49c40d1-3c9e-4aca-9d85-fab5a2486be5" />
